### PR TITLE
fix audio playback not working

### DIFF
--- a/src/mpv/mediampv.h
+++ b/src/mpv/mediampv.h
@@ -59,6 +59,8 @@ private:
     Media::State currentState = Media::StoppedState;
     bool aboutToFinishEmitted = false;
     QString lastErrorString;
+
+    QString audioFileToAdd;
 };
 
 #endif // MEDIAMPV_H


### PR DESCRIPTION
issue audio-add command after mpv emits signal that the loadfile command could successfully load the video file.
This fixes audio playback under linux when a youtube video should be played with separate video and audio streams