### PR TITLE
Fix compilation with more recent mpv

### DIFF
--- a/src/mpv/mpvwidget.cpp
+++ b/src/mpv/mpvwidget.cpp
@@ -34,7 +34,11 @@ void MpvWidget::initializeGL() {
     qDebug() << "initializeGL" << nativeParent;
     if (nativeParent == nullptr) qFatal("No native parent");
 
-    mpv_opengl_init_params gl_init_params{get_proc_address, this, nullptr};
+    #if MPV_CLIENT_API_VERSION < MPV_MAKE_VERSION(2,0)
+      mpv_opengl_init_params gl_init_params{get_proc_address, this, nullptr};
+    #else
+      mpv_opengl_init_params gl_init_params{get_proc_address, this};
+    #endif
     mpv_render_param params[]{{MPV_RENDER_PARAM_API_TYPE, (void *)MPV_RENDER_API_TYPE_OPENGL},
                               {MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &gl_init_params},
                               {MPV_RENDER_PARAM_INVALID, nullptr},


### PR DESCRIPTION
This pull requests incorporates the patch from the FreeBSD team:

https://cgit.freebsd.org/ports/commit/multimedia/minitube/files/patch-lib_media_src_mpv_mpvwidget.cpp?id=ac9b20c88deb90ca6604c7a07f4e36f826bffd6c

It is required with recent versions of mpv.

Your work in maintaining minitube is very much appreciated. :-)